### PR TITLE
docs: fix broken star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please refer to [Install on Server](https://lamina.levimc.org/user_guides/instal
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=LiteLDev/LeviLamina&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=LiteLDev/LeviLamina&type=Date)
 
 ## Acknowledgements
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -30,7 +30,7 @@ LeviLamina 是一个非官方的模组加载器，旨在为基岩版提供必不
 
 ## 星标蹭蹭涨
 
-![星标历史图](https://api.star-history.com/svg?repos=LiteLDev/LeviLamina&type=Date)
+![星标历史图](https://star-history.dera.page/svg?repos=LiteLDev/LeviLamina&type=Date)
 
 ## 致谢
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to upstream GitHub stargazer API restrictions, so it needs to be fixed. This updates the chart source in README.md and README.zh.md so the charts display correctly again.